### PR TITLE
Set inject_facts_as_vars = false in ansible.cfg

### DIFF
--- a/ansible-docker.sh
+++ b/ansible-docker.sh
@@ -27,6 +27,7 @@ fact_caching_timeout = 7200
 stdout_callback = yaml
 ansible_python_interpreter=/usr/bin/python3
 ansible_connection=local
+inject_facts_as_vars = false
 """ | tee ansible.cfg
 
   # create host list


### PR DESCRIPTION
This requires to use facts via ansible_facts only.

The setting is considered safer because a compromised host cannot inject facts into variables.

*This change can cause regressions.* Any ansible fact pushed as variable, see: https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_vars_facts.html#vars-and-facts
needs to be converted to `ansible_facts` namespace.

Something like:
```
git ls-files -z|grep -z yml|xargs -0r sed --follow-symlinks -Ei \
        "s/ansible_(virtualization_type|os_family|distribution\w*)/ansible_facts['\1']/g"
```

But this does not change handling for special / magic ansible variables: https://docs.ansible.com/ansible/latest/reference_appendices/special_variables.html

This setting is also recommended in some tuning guides like

https://docs.openstack.org/kolla-ansible/wallaby/user/ansible-tuning.html#fact-variable-injection

and issue mitigation guides:

https://docs.ansible.com/ansible/latest/reference_appendices/faq.html#when-is-it-unsafe-to-bulk-set-task-arguments-from-a-variable

I need this because of https://github.com/willshersystems/ansible-sshd/pull/244
and I could not find another way to change it.

Related actions like https://github.com/geerlingguy/ansible-for-devops/issues/529

Corrected: take on regressions