### PR TITLE
Install missing dependency on minimal fedora image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ LABEL "com.github.actions.color"="green"
 
 RUN dnf update --assumeyes && dnf install --assumeyes \
     python3 \
+    python3-libdnf5 \
     python3-pip \
     git
 


### PR DESCRIPTION
Sounds like the minimal image no longer has a python3-libdnf. This tries to install it.

The failures I am getting look like this:
```
TASK [Make sure openssh is installed before creating backup] *******************
fatal: [localhost]: FAILED! => changed=false 
  failures: []
  msg: Could not import the libdnf5 python module using /usr/bin/python3 (3.13.0 (main, Oct  8 2024, 00:00:00) [GCC 14.2.1 20240912 (Red Hat 14.2.1-3)]). Please install python3-libdnf5 package or ensure you have specified the correct ansible_python_interpreter. (attempted ['/usr/libexec/platform-python', '/usr/bin/python3', '/usr/bin/python'])
```