### PR TITLE
Install ansible from system repositories

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,10 +12,9 @@ LABEL "com.github.actions.color"="green"
 RUN dnf update --assumeyes && dnf install --assumeyes \
     python3 \
     python3-libdnf5 \
-    python3-pip \
+    python3-rpm \
+    ansible \
     git
-
-RUN pip3 install setuptools && pip3 install ansible
 
 RUN ansible --version
 


### PR DESCRIPTION
Installing ansible from pip is slow and problematic for various reasons. Using the packaged version should simplify installation and make sure we use the right ansible version.