### PR TITLE
Remove `yaml` as it was removed from community.general 12.0.0

### DIFF
--- a/ansible-docker.sh
+++ b/ansible-docker.sh
@@ -24,7 +24,6 @@ forks = 20
 fact_caching = jsonfile
 fact_caching_connection = $HOME/facts
 fact_caching_timeout = 7200
-stdout_callback = yaml
 ansible_python_interpreter=/usr/bin/python3
 ansible_connection=local
 inject_facts_as_vars = false


### PR DESCRIPTION
With the update to Fedora 44, the action started to fail like this:

https://github.com/willshersystems/ansible-sshd/actions/runs/24773001706/job/73778390628?pr=359

the cause is the yaml stdout callback, which was removed:

> Error: : The 'community.general.yaml' callback plugin has been removed. The plugin has been superseded by the option `result_format=yaml` in callback plugin ansible.builtin.default from ansible-core 2.13 onwards. This feature was removed from collection 'community.general' version 12.0.0.